### PR TITLE
LayerProxy

### DIFF
--- a/root/js/model/globe/LayerProxy.js
+++ b/root/js/model/globe/LayerProxy.js
@@ -5,46 +5,129 @@
 
 /*global WorldWind*/
 
+/**
+ * The LayerProxy modude is used to create a proxy for a WorldWind.Layer object. The proxy
+ * wraps the layer object and is endowed with additional observable properties that allow it 
+ * to controlled by the LayerManager and be displayed in the MVVM views.
+ * 
+ * @param {Knockout} ko
+ * @returns {LayerProxy}
+ */
 define([
     'knockout',
-    'jquery',
-    'model/util/Openable',
     'worldwind'],
-    function (ko, $, openable) {
+    function (ko) {
         "use strict";
 
+        /**
+         * @constructor
+         * @param {WorldWind.Layer} layer
+         * @returns {LayerProxy}
+         */
         var LayerProxy = function (layer) {
             var self = this;
 
+            /**
+             * The WorldWind layer proxied by this object
+             * @type WorldWind.Layer
+             */
             this.wwLayer = layer;
+            
+            //
+            // Observables
+            //
+            
+            /**
+             * The unique ID for this object (in the current session).
+             * @type Number
+             */
             this.id = ko.observable(LayerProxy.nextLayerId++);
+            
+            /**
+             * The layer category used to group layers.
+             * @type String
+             */
             this.category = ko.observable(layer.category);
+            
+            /**
+             * The name used for this layer in the layer lists.
+             * @type String
+             */
             this.name = ko.observable(layer.displayName);
+            
+            /**
+             * The enabled (visible) state of this layer.
+             * @type Boolean
+             */
             this.enabled = ko.observable(layer.enabled);
+            
+            /**
+             * The optional URL to a legend image.
+             * @type String
+             */
             this.legendUrl = ko.observable(layer.legendUrl ? layer.legendUrl.url : '');
+            
+            /**
+             * The opacity (tranparency) setting for this layer.
+             * @type Number
+             */
             this.opacity = ko.observable(layer.opacity);
+            
+            /**
+             * The sort order of this layer in its category.
+             * @type Number
+             */
             this.order = ko.observable();
+            
+            /**
+             * Flag to determine if this layer should appear in its category's layer list.
+             * @type Boolean
+             */
             this.showInMenu = ko.observable(layer.showInMenu);
+            
+            /**
+             * Flag to indicate if this layer is currently selected in the layer manager.
+             * @type Boolean
+             */
+            this.selected = ko.observable(false);
 
-            // Forward changes from enabled and opacity observables to the the layer object
+            //
+            // Event handlers
+            //
+
+            /**
+             * Forwards enabled state changes to the proxied layer object.
+             * @param {Boolean} newValue - The new state
+             */
             this.enabled.subscribe(function (newValue) {
-                layer.enabled = newValue;
+                self.wwLayer.enabled = newValue;
             });
+            
+            /**
+             * Forwards opacity changes to the proxied layer object.
+             * @param {Boolean} newValue - The new opacity
+             */
             this.opacity.subscribe(function (newValue) {
-                layer.opacity = newValue;
+                self.wwLayer.opacity = newValue;
             });
 
             // Mix-in the "openable" capability -- adds the isOpenable member and the "open" method. 
             // 
             // Opens the "layer-settings" JQuery dialog.
-            openable.makeOpenable(this, function () {   // define the callback that "opens" this layer
-                // Get the view model bound to the "layer-settings" element. See main.js for bindings
-                var layerDialog = ko.dataFor($("#layer-settings").get(0));
-                layerDialog.open(this);
-                return true; // return true to fire EVENT_OBJECT_OPENED event.
-            });
+//            openable.makeOpenable(this, function () {   // define the callback that "opens" this layer
+//                // Get the view model bound to the "layer-settings" element. See main.js for bindings
+//                var layerDialog = ko.dataFor($("#layer-settings").get(0));
+//                layerDialog.open(this);
+//                return true; // return true to fire EVENT_OBJECT_OPENED event.
+//            });
         };
-        
+
+        /**
+         * The next ID to be assigned.
+         * @type Number
+         * @inner
+         * @static
+         */
         LayerProxy.nextLayerId = 0;
 
         return LayerProxy;

--- a/root/js/viewmodels/LayersViewModel.js
+++ b/root/js/viewmodels/LayersViewModel.js
@@ -77,12 +77,16 @@ define([
 
             /**
              * Toggles the selected layer's visibility on/off
-             * @param {Object} layer The selected layer in the layer collection
+             * @param {LayerProxy} layer The selected layer in the layer collection
              */
             this.onToggleLayer = function (layer) {
                 layer.enabled(!layer.enabled());
                 globe.redraw();
             };
+            /**
+             * Sets the selected state to true; disables selected state of previous layer.
+             * @param {LayerProxy} layer
+             */
             this.onSelectLayer = function (layer) {
                 var lastLayer = self.selectedLayer();
                 if (lastLayer) {
@@ -90,10 +94,10 @@ define([
                 }
                 self.selectedLayer(layer);
                 layer.selected(true);
-            };            
+            };
             /**
              * Opens a dialog to edit the layer settings.
-             * @param {Object} layer The selected layer in the layer collection
+             * @param {LayerProxy} layer The selected layer in the layer collection
              */
             this.onEditSettings = function (layer) {
                 // 

--- a/root/js/views/settings.html
+++ b/root/js/views/settings.html
@@ -9,8 +9,50 @@ Settings tab (bound to SettingsViewModel)
             <a class="section-toggle" data-toggle="collapse" href="#settings-body"></a>
         </h4>
     </div>
-    <!--Date/Time-->
     <div id="settings-body" class="section-body collapse in">
+        <!--Display settings-->
+        <div class="panel panel-default">
+            <div class="panel-heading">Display Settings</div>
+            <div class="panel-body">
+                <div class="radio">
+                    <label>
+                        <input type="radio" name="optBackground" value="blue" data-bind="checked: backgroundColor">
+                        Blue Background
+                    </label>
+                </div>
+                <div class="radio">
+                    <label>
+                        <input type="radio" name="optBackground" value="black" data-bind="checked: backgroundColor">
+                        Black Background
+                    </label>
+                </div>
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" data-bind="checked: starsBackgroundEnabled">
+                        Show Stars
+                    </label>
+                </div>
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" data-bind="checked: atmosphereBackgroundEnabled">
+                        Show Atmosphere & Day/Night
+                    </label>
+                </div>
+                <div>
+                    Night Image:
+                    <div>
+                        <span class="pull-left"><i>Light</i></span>
+                        <span class="pull-right"><i>Dark</i></span>
+                    </div>
+                    <br/>
+                    <!--JQuery UI slider - created by custom Knockout binding (see main.js)-->
+                    <div id="night-opacity-slider" 
+                         data-bind="slider: nightOpacity, sliderOptions: {animate: 'fast', min: 0, max: 1, orientation: 'horizontal', step: 0.05}">
+                    </div>
+                </div>               
+            </div>            
+        </div>
+        <!--Date/Time-->
         <div class="panel panel-default">
             <div class="panel-heading">Date/Time Settings</div>
             <div class="panel-body">
@@ -39,57 +81,9 @@ Settings tab (bound to SettingsViewModel)
                 </div>                 
             </div>
         </div>
-        <!--Globe background-->
+        <!--Overlays-->
         <div class="panel panel-default">
-            <div class="panel-heading">Background</div>
-            <div class="panel-body">
-                <div class="radio">
-                    <label>
-                        <input type="radio" name="optBackground" value="blue" data-bind="checked: backgroundColor">
-                        Blue 
-                    </label>
-                </div>
-                <div class="radio">
-                    <label>
-                        <input type="radio" name="optBackground" value="black" data-bind="checked: backgroundColor">
-                        Black 
-                    </label>
-                </div>
-                <div class="checkbox">
-                    <label>
-                        <input type="checkbox" data-bind="checked: starsBackgroundEnabled">
-                        Show Stars
-                    </label>
-                </div>
-            </div>
-        </div>
-        <!--Effects -->
-        <div class="panel panel-default">
-            <div class="panel-heading">Effects</div>
-            <div class="panel-body">
-                <div class="checkbox">
-                    <label>
-                        <input type="checkbox" data-bind="checked: atmosphereBackgroundEnabled">
-                        Show Atmosphere & Day/Night
-                    </label>
-                </div>
-                <div>
-                    Night Image:
-                    <div>
-                        <span class="pull-left"><i>Light</i></span>
-                        <span class="pull-right"><i>Dark</i></span>
-                    </div>
-                    <br/>
-                    <!--JQuery UI slider - created by custom Knockout binding (see main.js)-->
-                    <div id="night-opacity-slider" 
-                         data-bind="slider: nightOpacity, sliderOptions: {animate: 'fast', min: 0, max: 1, orientation: 'horizontal', step: 0.05}">
-                    </div>
-                </div>               
-            </div>            
-        </div>
-        <!--Widgets-->
-        <div class="panel panel-default">
-            <div class="panel-heading">Widgets</div>
+            <div class="panel-heading">Overlay Settings</div>
             <div class="panel-body">
                 <div class="checkbox">
                     <label>


### PR DESCRIPTION
Minor refactoring to use a first-class LayerProxy object instead of a simple Object for the WorldWind.Layer view model. 

- Provides better locality of functions and documentation.
- Conveys its purpose
- Reduces confusion with the WorldWind layer objects