### PR TITLE
Use Cache-Control enabled server

### DIFF
--- a/root/js/model/globe/Globe.js
+++ b/root/js/model/globe/Globe.js
@@ -36,6 +36,7 @@
  * @author Bruce Schubert
  */
 define([
+    'model/globe/elevations/EnhancedEarthElevationModel',
     'model/globe/EnhancedTextSupport',
     'model/globe/KeyboardControls',
     'model/globe/LayerManager',
@@ -60,6 +61,7 @@ define([
     'model/Events',
     'knockout',
     'worldwind'], function (
+        EnhancedEarthElevationModel,
         EnhancedTextSupport,
         KeyboardControls,
         LayerManager,
@@ -107,6 +109,9 @@ define([
         publisher.makePublisher(this);
 
         this.wwd = wwd;
+        
+        // Replace the default globe with our custom version that uses cached terrain data
+        this.wwd.globe = new WorldWind.Globe(new EnhancedEarthElevationModel());
 
         // Enhance the behavior of the navigator: prevent it from going below the terrain
         this.enhanceLookAtNavigator(wwd.navigator);

--- a/root/js/model/globe/LayerManager.js
+++ b/root/js/model/globe/LayerManager.js
@@ -26,6 +26,8 @@ define([
     'model/globe/LayerProxy',
     'model/util/Log',
     'worldwind',
+    'model/globe/layers/EnhancedBMNGLayer',
+    'model/globe/layers/EnhancedLandsatLayer',
     'model/globe/layers/EoxOpenStreetMapLayer',
     'model/globe/layers/EoxSentinal2CloudlessLayer',
     'model/globe/layers/EoxSentinal2WithLabelsLayer',
@@ -42,6 +44,8 @@ define([
                 LayerProxy,
                 log,
                 ww,
+                EnhancedBMNGLayer,
+                EnhancedLandsatLayer,
                 EoxOpenStreetMapLayer,
                 EoxSentinal2CloudlessLayer,
                 EoxSentinal2WithLabelsLayer,
@@ -139,8 +143,8 @@ define([
              */
             LayerManager.prototype.loadDefaultLayers = function () {
                 // Define the Globe's default layers
-                this.addBaseLayer(new WorldWind.BMNGLayer(), {enabled: true, hideInMenu: false, detailControl: config.imagerydetailControl});
-                this.addBaseLayer(new WorldWind.BMNGLandsatLayer(), {enabled: false, detailControl: config.imagerydetailControl});
+                this.addBaseLayer(new EnhancedBMNGLayer(), {enabled: true, hideInMenu: false, detailControl: config.imagerydetailControl});
+                this.addBaseLayer(new EnhancedLandsatLayer(), {enabled: false, detailControl: config.imagerydetailControl});
                 this.addBaseLayer(new WorldWind.BingAerialWithLabelsLayer(null), {enabled: false, detailControl: config.imagerydetailControl});
                 this.addBaseLayer(new EoxSentinal2CloudlessLayer(), {enabled: false, detailControl: config.imagerydetailControl});
                 this.addBaseLayer(new EoxSentinal2WithLabelsLayer(), {enabled: false, detailControl: config.imagerydetailControl});

--- a/root/js/model/globe/elevations/EnhancedAsterV2ElevationCoverage.js
+++ b/root/js/model/globe/elevations/EnhancedAsterV2ElevationCoverage.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2003-2006, 2009, 2017, United States Government, as represented by the Administrator of the
+ * National Aeronautics and Space Administration. All rights reserved.
+ *
+ * The NASAWorldWind/WebWorldWind platform is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @exports AsterV2ElevationCoverage
+ */
+define([],
+    function () {
+        "use strict";
+
+        /**
+         * Constructs an Earth elevation coverage using ASTER V2 data.
+         * @alias AsterV2ElevationCoverage
+         * @constructor
+         * @augments TiledElevationCoverage
+         * @classdesc Provides elevations for Earth. Elevations are drawn from the NASA WorldWind elevation service.
+         */
+        var AsterV2ElevationCoverage = function () {
+            WorldWind.TiledElevationCoverage.call(this, {
+                coverageSector: new WorldWind.Sector(-83.0001, 83.0001, -180, 180),
+                resolution: 0.000277777777778,
+                retrievalImageFormat: "application/bil16",
+                minElevation: -11000,
+                maxElevation: 8850,
+                urlBuilder: new WorldWind.WmsUrlBuilder("https://emxsys.net/worldwind26/elev", "aster_v2", "", "1.3.0")
+            });
+
+            this.displayName = "ASTER V2 Earth Elevation Coverage";
+        };
+
+        AsterV2ElevationCoverage.prototype = Object.create(WorldWind.TiledElevationCoverage.prototype);
+
+        return AsterV2ElevationCoverage;
+    });

--- a/root/js/model/globe/elevations/EnhancedEarthElevationModel.js
+++ b/root/js/model/globe/elevations/EnhancedEarthElevationModel.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2003-2006, 2009, 2017, United States Government, as represented by the Administrator of the
+ * National Aeronautics and Space Administration. All rights reserved.
+ *
+ * The NASAWorldWind/WebWorldWind platform is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @exports EarthElevationModel
+ */
+define([
+        'model/globe/elevations/EnhancedAsterV2ElevationCoverage',
+        'model/globe/elevations/EnhancedGebcoElevationCoverage',
+        'model/globe/elevations/EnhancedUsgsNedElevationCoverage',
+        'model/globe/elevations/EnhancedUsgsNedHiElevationCoverage'
+    ],
+    function (AsterV2ElevationCoverage,
+              GebcoElevationCoverage,
+              UsgsNedElevationCoverage,
+              UsgsNedHiElevationCoverage) {
+        "use strict";
+
+        /**
+         * Constructs an EarthElevationModel consisting of three elevation coverages GEBCO, Aster V2, and USGS NED.
+         * @alias EarthElevationModel
+         * @constructor
+         */
+        var EarthElevationModel = function () {
+            WorldWind.ElevationModel.call(this);
+
+            this.addCoverage(new GebcoElevationCoverage());
+            this.addCoverage(new AsterV2ElevationCoverage());
+            this.addCoverage(new UsgsNedElevationCoverage());
+            this.addCoverage(new UsgsNedHiElevationCoverage());
+        };
+
+        EarthElevationModel.prototype = Object.create(WorldWind.ElevationModel.prototype);
+
+        return EarthElevationModel;
+    });

--- a/root/js/model/globe/elevations/EnhancedGebcoElevationCoverage.js
+++ b/root/js/model/globe/elevations/EnhancedGebcoElevationCoverage.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2003-2006, 2009, 2017, United States Government, as represented by the Administrator of the
+ * National Aeronautics and Space Administration. All rights reserved.
+ *
+ * The NASAWorldWind/WebWorldWind platform is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @exports GebcoElevationCoverage
+ */
+define([],
+    function () {
+        "use strict";
+
+        /**
+         * Constructs an Earth elevation coverage using GEBCO data.
+         * @alias GebcoElevationCoverage
+         * @constructor
+         * @augments TiledElevationCoverage
+         * @classdesc Provides elevations for Earth. Elevations are drawn from the NASA WorldWind elevation service.
+         */
+        var GebcoElevationCoverage = function () {
+            WorldWind.TiledElevationCoverage.call(this, {
+                coverageSector: WorldWind.Sector.FULL_SPHERE,
+                resolution: 0.008333333333333,
+                retrievalImageFormat: "application/bil16",
+                minElevation: -11000,
+                maxElevation: 8850,
+                urlBuilder: new WorldWind.WmsUrlBuilder("https://emxsys.net/worldwind26/elev", "GEBCO", "", "1.3.0")
+            });
+
+            this.displayName = "GEBCO Earth Elevation Coverage";
+        };
+
+        GebcoElevationCoverage.prototype = Object.create(WorldWind.TiledElevationCoverage.prototype);
+
+        return GebcoElevationCoverage;
+    });

--- a/root/js/model/globe/elevations/EnhancedUsgsNedElevationCoverage.js
+++ b/root/js/model/globe/elevations/EnhancedUsgsNedElevationCoverage.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2003-2006, 2009, 2017, United States Government, as represented by the Administrator of the
+ * National Aeronautics and Space Administration. All rights reserved.
+ *
+ * The NASAWorldWind/WebWorldWind platform is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @exports UsgsNedElevationCoverage
+ */
+define([],
+    function () {
+        "use strict";
+
+        /**
+         * Constructs an Earth elevation coverage using USGS NED data.
+         * @alias UsgsNedElevationCoverage
+         * @constructor
+         * @augments TiledElevationCoverage
+         * @classdesc Provides elevations for Earth. Elevations are drawn from the NASA WorldWind elevation service.
+         */
+        var UsgsNedElevationCoverage = function () {
+            // CONUS Extent: (-124.848974, 24.396308) - (-66.885444, 49.384358)
+            // TODO: Expand this extent to cover HI when the server NO_DATA value issue is resolved.
+            WorldWind.TiledElevationCoverage.call(this, {
+                coverageSector: new WorldWind.Sector(24.396308, 49.384358, -124.848974, -66.885444),
+                resolution: 0.000092592592593,
+                retrievalImageFormat: "application/bil16",
+                minElevation: -11000,
+                maxElevation: 8850,
+                urlBuilder: new WorldWind.WmsUrlBuilder("https://emxsys.net/worldwind26/elev", "USGS-NED", "", "1.3.0")
+            });
+
+            this.displayName = "USGS NED Earth Elevation Coverage";
+        };
+
+        UsgsNedElevationCoverage.prototype = Object.create(WorldWind.TiledElevationCoverage.prototype);
+
+        return UsgsNedElevationCoverage;
+    });

--- a/root/js/model/globe/elevations/EnhancedUsgsNedHiElevationCoverage.js
+++ b/root/js/model/globe/elevations/EnhancedUsgsNedHiElevationCoverage.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2003-2006, 2009, 2017, United States Government, as represented by the Administrator of the
+ * National Aeronautics and Space Administration. All rights reserved.
+ *
+ * The NASAWorldWind/WebWorldWind platform is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @exports UsgsNedHiElevationCoverage
+ */
+define([],
+    function () {
+        "use strict";
+
+        /**
+         * Constructs an Earth elevation coverage using USGS NED data.
+         * @alias UsgsNedHiElevationCoverage
+         * @constructor
+         * @augments TiledElevationCoverage
+         * @classdesc Provides elevations for Earth. Elevations are drawn from the NASA WorldWind elevation service.
+         */
+        var UsgsNedHiElevationCoverage = function () {
+            // Hawaii Extent: (-178.443593, 18.865460) - (-154.755792, 28.517269)
+            // TODO: Remove this class when the server NO_DATA value issue is resolved.
+            WorldWind.TiledElevationCoverage.call(this, {
+                coverageSector: new WorldWind.Sector(18.865460, 28.517269, -178.443593, -154.755792),
+                resolution: 0.000092592592593,
+                retrievalImageFormat: "application/bil16",
+                minElevation: -11000,
+                maxElevation: 8850,
+                urlBuilder: new WorldWind.WmsUrlBuilder("https://emxsys.net/worldwind26/elev", "USGS-NED", "", "1.3.0")
+            });
+
+            this.displayName = "USGS NED Hawaii Elevation Coverage";
+        };
+
+        UsgsNedHiElevationCoverage.prototype = Object.create(WorldWind.TiledElevationCoverage.prototype);
+
+        return UsgsNedHiElevationCoverage;
+    });

--- a/root/js/model/globe/layers/EnhancedBMNGLayer.js
+++ b/root/js/model/globe/layers/EnhancedBMNGLayer.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2003-2006, 2009, 2017, United States Government, as represented by the Administrator of the
+ * National Aeronautics and Space Administration. All rights reserved.
+ *
+ * The NASAWorldWind/WebWorldWind platform is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @exports BMNGLayer
+ */
+define([],
+    function () {
+        "use strict";
+
+        /**
+         * Constructs a Blue Marble image layer.
+         * @alias BMNGLayer
+         * @constructor
+         * @augments TiledImageLayer
+         * @classdesc Displays a Blue Marble image layer that spans the entire globe.
+         * @param {String} layerName The name of the layer to display, in the form "BlueMarble-200401"
+         * "BlueMarble-200402", ... "BlueMarble-200412". "BlueMarble-200405" is used if the argument is null
+         * or undefined.
+         */
+        var BMNGLayer = function (layerName) {
+            // This LevelSet configuration captures the Blue Marble resolution of 4.166666667E-03 degrees/pixel
+            WorldWind.TiledImageLayer.call(this,
+                WorldWind.Sector.FULL_SPHERE, new WorldWind.Location(45, 45), 7, "image/jpeg", layerName || "BMNG256", 256, 256);
+
+            this.displayName = "Blue Marble";
+            this.pickEnabled = false;
+
+            this.urlBuilder = new WorldWind.WmsUrlBuilder("https://emxsys.net/worldwind25/wms",
+                layerName || "BlueMarble-200405", "", "1.3.0");
+        };
+
+        BMNGLayer.prototype = Object.create(WorldWind.TiledImageLayer.prototype);
+
+        return BMNGLayer;
+    });

--- a/root/js/model/globe/layers/EnhancedLandsatLayer.js
+++ b/root/js/model/globe/layers/EnhancedLandsatLayer.js
@@ -1,0 +1,38 @@
+/* 
+ * Copyright (c) 2017 Bruce Schubert.
+ * The MIT License
+ * http://www.opensource.org/licenses/mit-license
+ */
+
+/* global define, WorldWind */
+
+/**
+ * The EnhancedWmsLayer provides vendor parameters to the GeoServer WMS GetMap 
+ * requests.
+ *
+ * @exports EnhancedWmsLayer
+ * @author Bruce Schubert
+ */
+define([
+    'WorldWindFixes', 
+    'worldwind'],
+    function (WorldWindFixes) {
+        "use strict";
+
+        var EnhancedLandsatLayer = function () {
+            // This LevelSet configuration captures the Landsat resolution of 1.38889E-04 degrees/pixel
+            WorldWind.TiledImageLayer.call(this,
+                WorldWind.Sector.FULL_SPHERE, new WorldWind.Location(45, 45), 12, "image/jpeg", "BMNGLandsat256", 256, 256);
+
+            this.displayName = "Blue Marble & Landsat";
+            this.pickEnabled = false;
+
+            this.urlBuilder = new WorldWind.WmsUrlBuilder("https://emxsys.net/worldwind25/wms",
+                "BlueMarble-200405,esat", "", "1.3.0");
+        };
+
+        EnhancedLandsatLayer.prototype = Object.create(WorldWind.TiledImageLayer.prototype);
+
+        return EnhancedLandsatLayer;
+    }
+);

--- a/root/js/model/globe/layers/UsgsImageryTopoBaseMapLayer.js
+++ b/root/js/model/globe/layers/UsgsImageryTopoBaseMapLayer.js
@@ -29,7 +29,8 @@ define([
             var cfg = {
                 title: "USGS Imagery Topo Basemap",
                 version: "1.3.0",
-                service: "https://basemap.nationalmap.gov:443/arcgis/services/USGSImageryTopo/MapServer/WmsServer?",
+//                service: "https://basemap.nationalmap.gov:443/arcgis/services/USGSImageryTopo/MapServer/WmsServer?",
+                service: "https://emxsys.net/USGSImageryTopo/MapServer/WmsServer?",
                 layerNames: "0",
                 sector: new WorldWind.Sector(-90.0, 90.0, -180, 180),
                 levelZeroDelta: new WorldWind.Location(180, 180),

--- a/root/js/model/globe/layers/UsgsTopoBaseMapLayer.js
+++ b/root/js/model/globe/layers/UsgsTopoBaseMapLayer.js
@@ -27,7 +27,8 @@ define([
         var cfg = {
             title: "USGS Topo Basemap",
             version: "1.3.0",
-            service: "https://basemap.nationalmap.gov:443/arcgis/services/USGSTopo/MapServer/WmsServer?",
+//            service: "https://basemap.nationalmap.gov:443/arcgis/services/USGSTopo/MapServer/WmsServer?",
+            service: "https://emxsys.net/USGSTopo/MapServer/WmsServer?",
             layerNames: "0",
             sector: new WorldWind.Sector(-90.0, 90.0, -180, 180),
             levelZeroDelta: new WorldWind.Location(180, 180),


### PR DESCRIPTION
Configured layers and elevations to use Cache-Control enabled server. Using Cache-Control headers improves client performance and reduces server workload.

Leveraging reverse proxy server services provided by emxsys.net for:
- WorldWind imagery (worldwind25)
- WorldWind elevations (worldwind26)
- USGS Topos (USGSTopo)
- USGS Imagery Topos (USGSImageryTopo)